### PR TITLE
Fix missing utility type Prettify in build

### DIFF
--- a/.changeset/quick-rules-help.md
+++ b/.changeset/quick-rules-help.md
@@ -1,0 +1,5 @@
+---
+'classic-react-hooks': patch
+---
+
+Fix missing utility type Prettify in build

--- a/apps/doc/hooks/use-event-listener.md
+++ b/apps/doc/hooks/use-event-listener.md
@@ -8,12 +8,12 @@ outline: deep
 
 ### Parameters
 
-| Parameter         |           Type            | Required | Default Value | Description                                         |
-| ----------------- | :-----------------------: | :------: | :-----------: | --------------------------------------------------- |
-| target            | [Target](#parametertype)  |    ✅    |       -       | Reference of the html element                       |
-| event             |          string           |    ✅    |       -       | Event name                                          |
-| handler           | [Handler](#parametertype) |    ❌    |   undefined   | Callback for the event                              |
-| options           | [Options](#parametertype) |    ❌    |   undefined   | For managing Event Propagation                      |
+| Parameter |           Type            | Required | Default Value | Description                    |
+| --------- | :-----------------------: | :------: | :-----------: | ------------------------------ |
+| target    | [Target](#parametertype)  |    ✅    |       -       | Reference of the html element  |
+| event     |          string           |    ✅    |       -       | Event name                     |
+| handler   | [Handler](#parametertype) |    ❌    |   undefined   | Callback for the event         |
+| options   | [Options](#parametertype) |    ❌    |   undefined   | For managing Event Propagation |
 
 ### Returns
 

--- a/apps/doc/hooks/use-outside-click.md
+++ b/apps/doc/hooks/use-outside-click.md
@@ -8,10 +8,10 @@ outline: deep
 
 ### Parameters
 
-| Parameter         |           Type            | Required | Default Value | Description                                         |
-| ----------------- | :-----------------------: | :------: | :-----------: | --------------------------------------------------- |
-| target            | [Target](#parametertype)  |    ✅    |       -       | Reference of the html element                       |
-| handler           | [Handler](#parametertype) |    ❌    |   undefined   | Callback for the event                              |
+| Parameter |           Type            | Required | Default Value | Description                   |
+| --------- | :-----------------------: | :------: | :-----------: | ----------------------------- |
+| target    | [Target](#parametertype)  |    ✅    |       -       | Reference of the html element |
+| handler   | [Handler](#parametertype) |    ❌    |   undefined   | Callback for the event        |
 
 ### Types
 

--- a/src/lib/use-counter/index.tsx
+++ b/src/lib/use-counter/index.tsx
@@ -1,4 +1,5 @@
 'use client'
+import type { Prettify } from '../../types'
 import React, { useCallback, useState } from 'react'
 import { capitalizeFirstLetter } from '../../utils/capitalize-first-letter'
 

--- a/src/lib/use-event-listener/index.tsx
+++ b/src/lib/use-event-listener/index.tsx
@@ -1,4 +1,5 @@
 'use client'
+import type { Prettify } from '../../types'
 import React, { RefObject, useEffect } from 'react'
 import useSyncedRef from '../use-synced-ref'
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,3 @@
-type Prettify<K> = {
+export type Prettify<K> = {
    [Key in keyof K]: K[Key]
 } & {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
          clean: true,
          all: true,
          include: ['src/lib/**/*'],
+         exclude: ['src/lib/use-combined-key-event-listener'],
       },
       include: ['src/lib/**/*.{test,spec}.{js,jsx,ts,tsx}'],
       exclude: [


### PR DESCRIPTION
- [fix: type missing in build for utility type Prettify](https://github.com/Ashish-simpleCoder/classic-react-hooks/commit/09caa936eaae8183e564b2f7b2a41578340d3552)