### PR TITLE
Fix working with ref for use-outside-click hook

### DIFF
--- a/.changeset/wise-grapes-thank.md
+++ b/.changeset/wise-grapes-thank.md
@@ -1,0 +1,5 @@
+---
+'classic-react-hooks': minor
+---
+
+Fix working with ref for use-outside-click hook

--- a/src/lib/use-outside-click/index.test.tsx
+++ b/src/lib/use-outside-click/index.test.tsx
@@ -53,6 +53,22 @@ describe('use-outside-click', () => {
       expect(removeSpy).toHaveBeenCalledTimes(1)
    })
 
+   it('should fire listener when clicked outside of target element when ref is provided', () => {
+      const div = document.createElement('div')
+      const ref = { current: div }
+      const listener = vi.fn()
+
+      renderHook(() => {
+         useOutsideClick(ref, listener)
+      })
+
+      const event = new Event('click')
+      document.dispatchEvent(event)
+
+      expect(listener).toHaveBeenCalledTimes(1)
+      expect(listener).toHaveBeenCalledWith(event)
+   })
+
    it('should fire listener when clicked outside of target element', () => {
       const div = document.createElement('div')
 

--- a/src/lib/use-outside-click/index.tsx
+++ b/src/lib/use-outside-click/index.tsx
@@ -41,8 +41,8 @@ export default function useOutsideClick(target: Target, handler: (event: Documen
 
       if (
          node &&
-         ((node as Node).contains(event.target as Node) ||
-            ('current' in node && (node.current as Node).contains(event.target as Node)))
+         (('contains' in node && (node as Node).contains(event.target as Node)) ||
+            ('current' in node && 'contains' && (node.current as Node).contains(event.target as Node)))
       ) {
          return
       }


### PR DESCRIPTION
- [fix: node.contains menthod not working with ref](https://github.com/Ashish-simpleCoder/classic-react-hooks/commit/ca3427adafbcf8d3a7de66550dfe53a434adf9a5)
- [test: add new test cases for handling ref working in use-outside-clic…](https://github.com/Ashish-simpleCoder/classic-react-hooks/commit/62ff1a3168bbd7795418ec2906a68d70570c702c)