### PR TITLE
docs: fix wrong editLink pattern url and initialValue param for `use-counter`

### DIFF
--- a/.changeset/few-waves-hammer.md
+++ b/.changeset/few-waves-hammer.md
@@ -1,0 +1,5 @@
+---
+'classic-react-hooks': minor
+---
+
+Add initialValue param for use-counter hook

--- a/apps/doc/.vitepress/config.mts
+++ b/apps/doc/.vitepress/config.mts
@@ -56,7 +56,7 @@ export default defineConfig({
          { icon: 'linkedin', link: 'https://linkedin.com/in/ashish-prajapati-002154193' },
       ],
       editLink: {
-         pattern: 'https://github.com/Ashish-simpleCoder/classic-react-hooks/edit/main/doc/:path',
+         pattern: 'https://github.com/Ashish-simpleCoder/classic-react-hooks/edit/main/apps/doc/:path',
          text: 'Edit this page on GitHub',
       },
 

--- a/src/lib/use-counter/index.test.tsx
+++ b/src/lib/use-counter/index.test.tsx
@@ -7,10 +7,10 @@ describe('use-counter', () => {
    })
 
    it('should return counter value of zero, incrementCounter and decrementCounter handlers with default key', () => {
-      const { result } = renderHook(() => useCounter())
+      const { result } = renderHook(() => useCounter('', 1))
 
       expect('counter' in result.current).not.toBeUndefined()
-      expect(result.current.counter).toBe(0)
+      expect(result.current.counter).toBe(1)
       expect('incrementCounter' in result.current).not.toBeUndefined()
       expect('decrementCounter' in result.current).not.toBeUndefined()
    })

--- a/src/lib/use-counter/index.tsx
+++ b/src/lib/use-counter/index.tsx
@@ -13,8 +13,8 @@ const LOWERCASED_COUNTER_TEXT = COUNTER_TEXT.toLowerCase() as Lowercase<typeof C
  * @see Docs https://classic-react-hooks.vercel.app/hooks/use-counter.html
  *
  */
-export default function useCounter<K extends string = ''>(key = '' as K) {
-   const [counter, setCounter] = useState(0)
+export default function useCounter<K extends string = ''>(key = '' as K, initialValue: number = 0) {
+   const [counter, setCounter] = useState(initialValue)
 
    const capitalizedKey = capitalizeFirstLetter(key)
 


### PR DESCRIPTION
- [feat: add initialValue param for use-counter](https://github.com/Ashish-simpleCoder/classic-react-hooks/commit/a14cd399df7a582e076c51be5720e533471f2900)
- [feat: add initialValue param for use-counter hook and add update the …](https://github.com/Ashish-simpleCoder/classic-react-hooks/commit/9eb1d46779c16dd7df8a911dabfdc67395289e0e)
- [docs: fix wrong editLink pattern url](https://github.com/Ashish-simpleCoder/classic-react-hooks/commit/e7a7175d8e1ae2b903be63feb9ef69982f75e447)